### PR TITLE
Chore/remove legacy code

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,1 @@
 .github/*
-src/*

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "@mithron/deezer-music-metadata": "^1.0.3"
+    "@mithron/deezer-music-metadata": "^1.0.3",
+    "blowfish-node": "^1.1.4"
   },
   "devDependencies": {
     "@discord-player/extractor": "^4.5.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "build": "yarn lint && tsup",
     "lint": "tslint -p tsconfig.json",
-    "npm:publish": "yarn build && npm publish --access public"
+    "npm:publish": "yarn build && npm publish --access public",
+    "prepare": "tsup"
   },
   "repository": {
     "type": "git",

--- a/src/DeezerExtractor.ts
+++ b/src/DeezerExtractor.ts
@@ -24,7 +24,6 @@ export type DeezerUserInfo = {
 }
 
 export const Warnings = {
-    LegacyOpenSSL: "OpenSSL legacy provider is needed for decrypting streams. Rerun your code with `node --openssl-legacy-provider` or set the environment variable NODE_OPTIONS to include `-openssl-legacy-provider`. Stream extraction has been disabled.",
     MissingDecryption: "Decryption Key missing! This is needed for extracting streams."
 } as const
 export type Warnings = (typeof Warnings)[keyof typeof Warnings]

--- a/src/DeezerExtractor.ts
+++ b/src/DeezerExtractor.ts
@@ -36,16 +36,6 @@ export class DeezerExtractor extends BaseExtractor<DeezerExtractorOptions> {
     async activate(): Promise<void> {
         if(!this.options.decryptionKey) process.emitWarning(Warnings.MissingDecryption)
         else {
-            if(typeof process.env.NODE_OPTIONS === "string" && !process.env.NODE_OPTIONS.includes("--openssl-legacy-provider")) {
-                process.emitWarning(Warnings.LegacyOpenSSL)
-                this.options.decryptionKey = undefined
-                return;
-            }
-            if(!process.execArgv.includes("--openssl-legacy-provider")) {
-                process.emitWarning(Warnings.LegacyOpenSSL)
-                this.options.decryptionKey = undefined;
-                return
-            }
             // extract deezer username
             // dynamically load crypto because some might not want streaming
             const crypto = await getCrypto()

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -159,15 +159,15 @@ export async function streamTrack(track: Track, ext: DeezerExtractor) {
             } else {
                 buffer = Buffer.concat([buffer, chunk])
             }
-
-            const blowfishDecrypter = new Blowfish(trackKey, Blowfish.MODE.CBC)
-            blowfishDecrypter.setIv(IV)
+            
+            const blowfishDecrypter = new Blowfish(new Uint8Array(trackKey), Blowfish.MODE.CBC)
+            blowfishDecrypter.setIv(new Uint8Array(IV))
 
             while (buffer.length >= bufferSize) {
                 const bufferSized = buffer.subarray(0, bufferSize)
 
                 if (i % 3 === 0) {
-                    const decipher = Buffer.from(blowfishDecrypter.decode(bufferSized, Blowfish.TYPE.UINT8_ARRAY))
+                    const decipher = Buffer.from(blowfishDecrypter.decode(new Uint8Array(bufferSized), Blowfish.TYPE.UINT8_ARRAY))
                     passThrough.write(decipher)
                 } else {
                     passThrough.write(bufferSized)

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -160,7 +160,7 @@ export async function streamTrack(track: Track, ext: DeezerExtractor) {
                 buffer = Buffer.concat([buffer, chunk])
             }
             
-            const blowfishDecrypter = new Blowfish(new Uint8Array(trackKey), Blowfish.MODE.CBC)
+            const blowfishDecrypter = new Blowfish(new Uint8Array(trackKey), Blowfish.MODE.CBC, Blowfish.PADDING.NULL)
             blowfishDecrypter.setIv(new Uint8Array(IV))
 
             while (buffer.length >= bufferSize) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -417,6 +417,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+blowfish-node@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.npmjs.org/blowfish-node/-/blowfish-node-1.1.4.tgz#37bfe62a08f6d6026407399ad214c44d5bb4e01f"
+  integrity sha512-Iahpxc/cutT0M0tgwV5goklB+EzDuiYLgwJg050AmUG2jSIOpViWMLdnRgBxzZuNfswAgHSUiIdvmNdgL2v6DA==
+
 boolbase@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"


### PR DESCRIPTION
This removes the need to use `--open-legacy-provider` in Node options.